### PR TITLE
Add fetch of license risk information

### DIFF
--- a/src/main/java/net/regnology/lucy/service/LibraryCustomService.java
+++ b/src/main/java/net/regnology/lucy/service/LibraryCustomService.java
@@ -254,6 +254,15 @@ public class LibraryCustomService extends LibraryService {
             Optional<License> optionalLicense = licenseService.findOne(lpp.getLicense().getId());
             optionalLicense.ifPresent(lpp::setLicense);
         }
+        
+        for (License license : library.getLicenseToPublishes()) {
+            if (license.getLicenseRisk() == null) {
+                Optional<License> optionalLicense = licenseService.findOne(license.getId());
+                if (optionalLicense.isPresent()) {
+                    license.setLicenseRisk(optionalLicense.get().getLicenseRisk());
+                }
+            }
+        }
 
         if (
             library.getLicenses().isEmpty() ||


### PR DESCRIPTION
Fixes #17.

If the license risk of a license in the LicenseToPublish list is missing then it fetches the full license from the database and set the license risk. This fix the problem that the library risk couldn't be calculated because the risk information was missing.

The bug only occurred when the LicenseToPublish was set manually, because the frontend only knows the name and ID of the license and thus the rest of the information, like the license risk, was missing.