### PR TITLE
Implemented URL validator before downloading license text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+## [0.6.4] - 2023-06-22
+
+### Added 
+- Added URL verifier before downloading license text 
+
+### Changed
+- Exporting full reports as CVS is now working 
+- Unknown libraries can now be edited and saved in a way that also update the license risk score. 
 
 ## [0.6.3] - 2022-12-23
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>net.regnology.lucy</groupId>
     <artifactId>lucy</artifactId>
-    <version>0.6.3</version>
+    <version>0.6.4</version>
     <packaging>jar</packaging>
 
     <name>Lucy</name>

--- a/src/main/java/net/regnology/lucy/service/LicenseCustomService.java
+++ b/src/main/java/net/regnology/lucy/service/LicenseCustomService.java
@@ -3,7 +3,9 @@ package net.regnology.lucy.service;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.net.MalformedURLException;
 import java.net.URISyntaxException;
+import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
@@ -397,6 +399,19 @@ public class LicenseCustomService extends LicenseService {
 
         return licenseUrls;
     }
+    /**
+     * Validates URL.
+     */
+    public boolean isValidURL(String url) throws MalformedURLException, URISyntaxException {
+        try {
+            new URL(url).toURI();
+            return true;
+        } catch (MalformedURLException e) {
+            return false;
+        } catch (URISyntaxException e) {
+            return false;
+        }
+    }
 
     /**
      * Downloads the HTML page from an URL.
@@ -408,7 +423,11 @@ public class LicenseCustomService extends LicenseService {
      * @throws InterruptedException if the download gets interrupted
      */
     public String downloadLicenseText(String url) throws URISyntaxException, IOException, InterruptedException {
-        log.debug("Downloading URL : {}", url);
+        //cleanup of strange url from NPM projects
+        if (!isValidURL(url)){
+            log.info("Download License Text failed due to: invalid URI scheme ");
+            return "";
+        }
 
         if (url.contains("github.com") && url.contains("/blob/")) {
             url = url.replace("github.com", "raw.githubusercontent.com").replace("raw.raw.", "raw.").replace("/blob/", "/");


### PR DESCRIPTION
Implemented URL validator. When _downloadLicenseText_  the invalid URLs are getting discarded.
Updated the Changelog.md to reflect the current development state  
Updated Lucys version to 0.6.4    